### PR TITLE
[HNC-522] - Change detection should ignore the release manifest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Aims to focus maven builds for certain submodules. When executing a Maven build,
 # Calling Change detection composite action in workflow
 - name: Change detection Composite action
   id: change_detection
-  uses: hv-actions/change-detection-builder@develop
+  uses: hv-actions/change-detection-builder@stable  #The stable tag always points to the latest changes
 ```
 
 ```
 #Build The Project for changed modules
 - name: Build
   id: Build
-  uses: lumada-common-services/gh-composite-actions@develop
+  uses: lumada-common-services/gh-composite-actions@stable
   with:
     command: mvn clean install -pl "${{ steps.change_detection.outputs.changed_modules }}"  -DskipTests -amd -s ${{env.MAVEN_SETTINGS}}
 ```
@@ -27,5 +27,12 @@ This composite system performs two main tasks: detecting files that have changed
   - -pl "./module1_path, ./module2_path": The -pl option, followed by a comma-separated list of module paths, allows you to specify specific modules to build. In this case, it indicates that only the modules named "module1" and "module2" should be built. Other modules in the project will be skipped.
   - -amd: The -amd option, short for "also make dependencies," is a non-standard option typically used with the Maven reactor. When this option is enabled, Maven will build not only the specified modules (module1 and module2) but also their dependent modules if they have changed since the last build. It ensures that the dependencies are up to date.
 - If no files have been changed, the value of ${{ steps.change_detection.outputs.changed_modules }} is set to the current directory, represented by ".". Running the Maven build command with -pl "${{ steps.change_detection.outputs.changed_modules }}" will then build all submodules in the project.
-
+- As a default, it will exclude these paths ```'.yaml, .yml, .github/'``` while running the change detection. However, if we want to exclude specific paths or files ending with a particular extension, we can define that value as follows
+```
+- name: Change detection Composite action
+  id: change_detection
+  uses: hv-actions/change-detection-builder@stable
+  with:
+    exclude_paths: '.github/, .frogbot/, .json, .py'
+```
 In summary, this script optimizes the build process by selectively building only the necessary submodules when changes are detected, improving overall build efficiency.

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,12 @@
 name: "Change-detection_builder"
 description: "Change-detection_builder"
 
+inputs:
+  exclude_paths:
+    description: '"Path to exclude while running change detection.'
+    type: string
+    default: '.yaml, .yml, .github/'
+    
 outputs:
   changed_modules:
     description: "Path of modules which got changed"
@@ -24,5 +30,6 @@ runs:
         echo "${{ steps.changes.outputs.all }}"
         python3 ${GITHUB_ACTION_PATH}/maven.py \
           "${{ steps.changed-files.outputs.all_changed_files }}" \
-          "${GITHUB_WORKSPACE}" 
+          "${GITHUB_WORKSPACE}" \
+          "${{ inputs.exclude_paths }}"
       shell: bash

--- a/maven.py
+++ b/maven.py
@@ -19,14 +19,21 @@ def find_parent_pom_directory_for_all_changed_files(changed_files,github_workspa
 #Reading all changed files path from arguments
 path = sys.argv[1]
 github_workspace_path = sys.argv[2]
+exclude_paths = sys.argv[3]
+
+exclude_paths = [item.strip() for item in exclude_paths.split(',')]
+print(f" exclude path list - {exclude_paths} ")
 
 #Converting space separated string into array list and storing output in variable
 changed_files = path.split()
 print(f" All changed files - {changed_files} ")
 
 #Here we are excluding all workflow path which got changed while triggering the workflow
-changed_files_exclude_yaml = [[f for f in changed_files if not f.endswith(".yaml") and not f.endswith(".yml") or not f.startswith(".github/workflows/")]]
-print(f" Changed file after excluding workflow yaml files - {changed_files_exclude_yaml} ")
+changed_files_exclude_yaml = [[
+    file for file in changed_files
+    if not any(item in file for item in exclude_paths)
+]]
+print(f" Changed the file after excluding all paths provided in the exclude path list - {changed_files_exclude_yaml} ")
 
 #If no file got changed then we are setting root directory path
 if len(changed_files_exclude_yaml[0]) == 0:


### PR DESCRIPTION
Now, the change detection action is ignoring all the YAML files.
[link](https://github.com/pentaho/pdi-plugins-ee/actions/runs/7273679550/job/19818128967)

![image](https://github.com/hv-actions/change-detection-builder/assets/112469025/dfb843b0-1bcf-40ea-8c07-e6178063c80a)
