### PR TITLE
[HNC-568] - Update tj-actions/changed-files action tag to v42

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,7 +22,7 @@ runs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v37
+      uses: tj-actions/changed-files@v42
     
     - name: Python command
       id: python_script


### PR DESCRIPTION
Example - https://github.com/pentaho/pdi-plugins-ee/actions/runs/8111891188
It's not showing a warning for change detection now